### PR TITLE
Move to no_std. Set MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "vec_mut_scan"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jannis Harder <me@jix.one>"]
 edition = "2018"
 description = "Forward scan over a vector with mutation and item removal"
 repository = "https://github.com/jix/vec_mut_scan"
 license = "0BSD"
 readme = "README.md"
-keywords = ["vec", "retain", "drain", "drain_filter"]
-categories = ["algorithms", "data-structures"]
+keywords = ["no_std", "vec", "retain", "drain", "drain_filter"]
+categories = ["no-std", "algorithms", "data-structures"]
+rust-version = "1.36.0"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 //! Forward scan over a vector with mutation and item removal.
-use std::{
-    collections::VecDeque,
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::VecDeque, vec::Vec};
+use core::{
     mem,
     ops::{Deref, DerefMut},
     ptr,
@@ -137,8 +141,8 @@ impl<'a, T: 'a> VecMutScan<'a, T> {
             // These slices cover the two disjoint parts 0..write and read..end which contain the
             // currently valid data.
             (
-                std::slice::from_raw_parts(self.base, self.write),
-                std::slice::from_raw_parts(self.base.add(self.read), self.end - self.read),
+                core::slice::from_raw_parts(self.base, self.write),
+                core::slice::from_raw_parts(self.base.add(self.read), self.end - self.read),
             )
         }
     }
@@ -158,8 +162,8 @@ impl<'a, T: 'a> VecMutScan<'a, T> {
             // These slices cover the two disjoint parts 0..write and read..end which contain the
             // currently valid data.
             (
-                std::slice::from_raw_parts_mut(self.base, self.write),
-                std::slice::from_raw_parts_mut(self.base.add(self.read), self.end - self.read),
+                core::slice::from_raw_parts_mut(self.base, self.write),
+                core::slice::from_raw_parts_mut(self.base.add(self.read), self.end - self.read),
             )
         }
     }
@@ -220,7 +224,7 @@ impl<'s, 'a, T: 'a> VecMutScanItem<'s, 'a, T> {
 
     /// Replaces this item with a new value, returns the old value.
     ///
-    /// This is equivalent to assigning a new value or calling [`std::mem::replace`] on the mutable
+    /// This is equivalent to assigning a new value or calling [`mem::replace`] on the mutable
     /// reference obtained by using [`DerefMut`], but can avoid an intermediate move within the
     /// vector's buffer.
     pub fn replace(self, value: T) -> T {
@@ -446,10 +450,10 @@ impl<'a, T: 'a> VecGrowScan<'a, T> {
             // These slices cover the two disjoint parts 0..write and read..end which contain the
             // currently valid data.
             (
-                std::slice::from_raw_parts(self.base, self.write),
+                core::slice::from_raw_parts(self.base, self.write),
                 mid_l,
                 mid_r,
-                std::slice::from_raw_parts(self.base.add(self.read), self.end - self.read),
+                core::slice::from_raw_parts(self.base.add(self.read), self.end - self.read),
             )
         }
     }
@@ -471,10 +475,10 @@ impl<'a, T: 'a> VecGrowScan<'a, T> {
             // These slices cover the two disjoint parts 0..write and read..end which contain the
             // currently valid data.
             (
-                std::slice::from_raw_parts_mut(self.base, self.write),
+                core::slice::from_raw_parts_mut(self.base, self.write),
                 mid_l,
                 mid_r,
-                std::slice::from_raw_parts_mut(self.base.add(self.read), self.end - self.read),
+                core::slice::from_raw_parts_mut(self.base.add(self.read), self.end - self.read),
             )
         }
     }
@@ -606,7 +610,7 @@ impl<'s, 'a, T: 'a> VecGrowScanItem<'s, 'a, T> {
 
     /// Replaces this item with a new value, returns the old value.
     ///
-    /// This is equivalent to assigning a new value or calling [`std::mem::replace`] on the mutable
+    /// This is equivalent to assigning a new value or calling [`mem::replace`] on the mutable
     /// reference obtained by using [`DerefMut`], but can avoid an intermediate move within the
     /// vector's buffer.
     pub fn replace(mut self, value: T) -> T {
@@ -745,7 +749,7 @@ impl<'s, 'a, T: 'a> Drop for VecGrowScanItem<'s, 'a, T> {
 mod tests {
     use super::*;
 
-    use std::rc::Rc;
+    use alloc::{boxed::Box, rc::Rc, vec};
 
     #[test]
     fn check_item_drops() {


### PR DESCRIPTION
Just moving from `std` to `core` and `alloc`. MSRV is 1.36.0 due to stabilization of `alloc`